### PR TITLE
Boton dinamico demo-idpal en demo carros

### DIFF
--- a/src/app/components/car-dealer/landing/landing.component.html
+++ b/src/app/components/car-dealer/landing/landing.component.html
@@ -136,9 +136,7 @@
                 <div class="et_pb_button_module_wrapper et_pb_button_0_wrapper et_pb_button_alignment_center et_pb_module ">
                   <a 
                     class="et_pb_button et_pb_button_0 et_pb_bg_layout_dark" 
-                    id="Maat-authenticate"
-                    onclick='Maat.showIFrame("idpal", "8a66d05d-1650-b24c-a05b-8d42836155ed", "4759695283716096,6232102555090944,5706627130851328,4920671865929728,5460536974114816,6537098242818048,5702590167777280", "External comment TEst");' 
-                    >
+                    id="Maat-authenticate" onclick="maatAuthenticate()">
                     COTIZA TU CRÉDITO
                     <span><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M17.25 8.25L21 12m0 0l-3.75 3.75M21 12H3" />
@@ -149,6 +147,7 @@
               <div class="et_pb_column et_pb_column_1_3 et_pb_column_1  et_pb_css_mix_blend_mode_passthrough et-last-child et_pb_column_empty"></div>
             </div>
           </div>
+
           <div class="et_pb_section et_pb_section_1 et_pb_with_background et_section_regular et_section_transparent section_has_divider et_pb_bottom_divider">
             <div class="et_pb_row et_pb_row_1 et_pb_row_fullwidth">
               <div class="et_pb_column et_pb_column_1_2 et_pb_column_2  et_pb_css_mix_blend_mode_passthrough">

--- a/src/index.html
+++ b/src/index.html
@@ -77,6 +77,12 @@
       console.log(numero);
       console.log(numero.detail);
     }
+    function maatAuthenticate() {
+      Maat.showIFrameButton("maat-demo", "demo-idpal", "", function(data) {
+        console.log("Respuesta:");
+        console.log(data);
+      });
+    }
   </script>
   <script src="https://demo.maatai.com/widget/js/widget.v2.js" onload="maat_loaded"></script>
   


### PR DESCRIPTION
Se hizo cambios para mapear el boton nuevo dinamico de nombre demo-idpal, para el cliente maat-demo.